### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jasmine-expect",
   "version": "1.20.0",
   "description": "35+ additional matchers for the Jasmine BDD JavaScript test library",
-  "main": "jasmine-matchers.js",
+  "main": "dist/jasmine-matchers.js",
   "author": "Jamie Mason (https://github.com/JamieMason)",
   "license": "MIT",
   "gitHead": "76aba51fb924e3f3c9b172174a7ee7296a0d950b",


### PR DESCRIPTION
`require('jsamine-expect');` does not work under Node.js until `dist` is prepended to the `main` path.
