### PR TITLE
expand object test to include typeof 'object'

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -6,7 +6,7 @@
    * @return {Boolean}
    */
   matchers.toBeObject = function() {
-    return this.actual instanceof Object;
+    return this.actual instanceof Object || (typeof this.actual === 'object');
   };
 
   /**


### PR DESCRIPTION
There's an issue jasmine-matchers with webdriver.  In particular, I'm using this as part of a protractor test suite, where I'm testing the return value of executing a script on the page.  The error is:

"Expected { host : 'my-host.com', other_attribute : '' } to be object."

myObj instanceof Object => false
typeof myObj => 'object'

I know this is actually a data serialization issue, but it'd be nice to be slightly more lax.
