### PR TITLE
fix(bower) EMALFORMED Failed to read

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
     "index.js",
     "node_modules",
     "src",
-    "test",
+    "test"
   ]
 }


### PR DESCRIPTION
When bower install this repos (tag 2.0.0-beta1), there is an error : bower jasmine-expect#~2.0.0                         EMALFORMED Failed to read /tmp/mathieu/bower/jasmine-expect-5161-vppAmT/bower.json
