### PR TITLE
Node installation instructions are missing a step

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Use the [Jasmine CLI](https://www.npmjs.com/package/jasmine) and include the pat
 }
 ```
 
+Then add `require("jasmine-expect")` to your spec helper file. 
+
 ### Sublime Text
 
 [Jasmine-Matchers-Snippets](https://github.com/JamieMason/Jasmine-Matchers-Snippets) or [Jasmine-Matchers-ES6-Snippets](https://github.com/JamieMason/Jasmine-Matchers-ES6-Snippets) can be installed with [Package Control](https://packagecontrol.io/packages/Jasmine%20Matchers%20Snippets) to ease development with Jasmine Matchers in Sublime Text.


### PR DESCRIPTION
It did not suffice for me to just add the node_modules/jasmine-expect/index.js line to the helpers array. I also had to add `require("jasmine-expect")` to my spec helper file. I just recently found this project and am setting it up for the first time. I don't know how it works under-the-hood, but I think this is useful info to have in the README in case others encounter the same situation.
