### PR TITLE
Fix Typescript Mismatch with @types/jasmine

### DIFF
--- a/jasmine-matchers.d.ts
+++ b/jasmine-matchers.d.ts
@@ -1,5 +1,5 @@
 declare namespace jasmine {
-  interface Matchers {
+  interface Matchers<T> {
     toBeAfter(otherDate: Date, expectationFailOutput?: any): boolean;
     toBeArray(expectationFailOutput?: any): boolean;
     toBeArrayOfBooleans(expectationFailOutput?: any): boolean;


### PR DESCRIPTION
Currently, there's a mismatch with `@types/jasmine` that throws the following error:
```
node_modules/@types/jasmine/index.d.ts(404,15): error TS2428: All declarations of 'Matchers' must have identical type parameters.
node_modules/jasmine-expect/jasmine-matchers.d.ts(2,13): error TS2428: All declarations of 'Matchers' must have identical type parameters.
```
this adjustment fix the Typescript definitions of the project. Refs #62

My `package.json` looks like:
```
    "devDependencies": {
        "@types/jasmine": "^2.7.3",
        "@types/lodash": "^4.14.88",
        "@types/moment-timezone": "^0.2.35",
        "@types/node": "^8.0.57",
        "jasmine": "^2.8.0",
        "jasmine-expect": "^3.8.1",
        "tslint": "~5.7.0",
        "typescript": "~2.4.2"
    },
```
and the `tsconfig.json`:
```
{
    "compilerOptions": {
        "target": "es5",
        "module": "commonjs",
        "alwaysStrict": true,
        "noImplicitReturns": true,
        "noImplicitThis": true,
        "noUnusedParameters": true,
        "noUnusedLocals": true,
        "noEmitOnError": true,
        "noImplicitAny": true,
        "preserveConstEnums": true,
        "experimentalDecorators": false,
        "sourceMap": false,
        "inlineSourceMap": true,
        "declaration": true,
        "strict": true,
        "strictNullChecks": true,
        "lib": [
            "es5",
            "es2015",
            "dom"
        ],
        "types": [
            "node",
            "jasmine",
            "jasmine-expect"
        ],
        "rootDir": "./",
        "sourceRoot": "./",
        "outDir": "./dist/"
    },
    "exclude": [
        "dist",
        "node_modules"
    ]
}
```

Probably a minor release will be needed to not cause a breaking change to the projects using `3.8.*` without problems.