### PR TITLE
chore(core): Add jest support

### DIFF
--- a/jasmine-matchers.d.ts
+++ b/jasmine-matchers.d.ts
@@ -85,3 +85,8 @@ declare namespace jasmine {
     toThrowErrorOfType(type: string, expectationFailOutput?: any): boolean;
   }
 }
+
+declare namespace jest {
+  interface Matchers<R> extends jasmine.Matchers<R> {
+  }
+}


### PR DESCRIPTION
Jest(https://facebook.github.io/jest/) is based on jasmine and supports extending jasmine matchers as well.

I'm using jest and adding this matcher. As I do not have the jasmine declaration file (since I have the Jest one instead) namespace `jasmine` does not exist (instead I have `jest` namespace... see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts)

This PR add the ability to use the jasmine matcher types in jest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jamiemason/jasmine-matchers/98)
<!-- Reviewable:end -->
