### PR TITLE
main should point to src/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "testing"
   ],
   "license": "MIT",
-  "main": "dist/jasmine-matchers.js",
+  "main": "src/index.js",
   "repository": "JamieMason/Jasmine-Matchers",
   "scripts": {
     "browserstack-android": "echo 'TEMPORARILY DISABLED: karma start karma/browserstack-android.conf.js'",


### PR DESCRIPTION
The expected way of programmatically load  a jasmine helper, is to require() it from a spec helper before specs are loaded. Unfortunately ```require('jasmine-expect')``` will fail if compiled with browserify with:

```
echo "require('jasmine-expect')" > test.js
browserify test.js -o testbundle.js
Error: Cannot find module './src/create-register' from '/home/sg/git/WASM-ImageMagick/node_modules/jasmine-expect/dist'
```

What does the trick is ```require('../../node_modules/jasmine-expect/src/index.js')``` which unfortunately is risky and not elegant. I think other tools like webpack or rollup will also fail the same way - and it's very common to create a bundle with specs like this when running tests outside node.js , for example in an headless browser.