### PR TITLE
update `isFunction` to support `async`

### DIFF
--- a/src/lib/is.ts
+++ b/src/lib/is.ts
@@ -4,12 +4,17 @@ const createIs = (type) => (value) =>
 const createIsBooleanObject = (trueOrFalse) => (value) =>
   is.Boolean(value) && value.valueOf() === trueOrFalse;
 
+const createIsFunction = () => {
+  const syncFn = createIs('Function'), asyncFn = createIs('AsyncFunction');
+  return (value) => syncFn(value) || asyncFn(value);
+}
+
 export const is = {
   Array: createIs('Array'),
   Boolean: createIs('Boolean'),
   Date: createIs('Date'),
   False: createIsBooleanObject(false),
-  Function: createIs('Function'),
+  Function: createIsFunction(),
   Object: createIs('Object'),
   String: createIs('String'),
   True: createIsBooleanObject(true),

--- a/src/lib/is.ts
+++ b/src/lib/is.ts
@@ -5,9 +5,10 @@ const createIsBooleanObject = (trueOrFalse) => (value) =>
   is.Boolean(value) && value.valueOf() === trueOrFalse;
 
 const createIsFunction = () => {
-  const syncFn = createIs('Function'), asyncFn = createIs('AsyncFunction');
+  const syncFn = createIs('Function');
+  const asyncFn = createIs('AsyncFunction');
   return (value) => syncFn(value) || asyncFn(value);
-}
+};
 
 export const is = {
   Array: createIs('Array'),

--- a/test/toBeFunction.spec.js
+++ b/test/toBeFunction.spec.js
@@ -4,6 +4,9 @@ describe('toBeFunction', () => {
       it('should confirm', () => {
         expect(() => {}).toBeFunction();
       });
+      it('should confirm for async functions', () => {
+        expect(async () => {}).toBeFunction();
+      });
     });
     describe('when subject is NOT a function', () => {
       it('should deny', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
     extensions: ['.ts', '.js']
   },
   output: {
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    hashFunction: 'sha512'
   }
 };


### PR DESCRIPTION
## Description (What)

Updates the `isFunction` matcher to properly identify and support `async` functions.

## Justification (Why)
Async functions are pretty common, and should be treated as valid in the `isFunction` matcher

## How Can This Be Tested?

`isFunction.spec.js` has been updated to include a test for async functions
